### PR TITLE
test: prepare GUT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vscode/
 .directory
 bin/
+
+addons/gut

--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,10 @@ SceneSwitcher="*res://globals/scene_switcher.gd"
 window/stretch/mode="canvas_items"
 window/stretch/scale_mode="integer"
 
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gut/plugin.cfg")
+
 [gui]
 
 theme/custom="res://theme.tres"

--- a/test/unit/test_example.gd
+++ b/test/unit/test_example.gd
@@ -1,0 +1,9 @@
+extends GutTest
+
+func test_passes():
+	# this test will pass because 1 does equal 1
+	assert_eq(1, 1)
+
+func test_fails():
+	# this test will fail because those strings are not equal
+	assert_eq('hello', 'goodbye')


### PR DESCRIPTION
GUT is a framework to allow for writing tests in Godot. Since it is installed by each Godot editor instance I'm merely tracking the presence of the folder here.

Please see GUT Installation Guide for installation and setup. https://gut.readthedocs.io/en/latest/Quick-Start.html

Fixes #1 